### PR TITLE
Fix closing relayed connections

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish npm package to gitea
+on:
+  release:
+    types: [published]
+jobs:
+  npm_publish:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 16.x ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - name: Run npm build
+        run: |
+          npm run build
+      - name: Configure git.vdb.to npm registry
+        run: |
+          npm config set registry https://git.vdb.to/api/packages/cerc-io/npm/
+      - name: Authenticate to git.vdb.to registry
+        run: |
+          npm config set -- '//git.vdb.to/api/packages/cerc-io/npm/:_authToken' "${{ secrets.GITEA_PUBLISH_TOKEN }}"
+      - name: npm publish
+        run: |
+          npm publish

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "libp2p",
-  "version": "0.42.2",
+  "name": "@cerc-io/libp2p",
+  "version": "0.42.2-laconic-0.1.1",
   "description": "JavaScript implementation of libp2p, a modular peer to peer network stack",
   "license": "Apache-2.0 OR MIT",
   "homepage": "https://github.com/libp2p/js-libp2p#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/libp2p",
-  "version": "0.42.2-laconic-0.1.1",
+  "version": "0.42.2-laconic-0.1.0",
   "description": "JavaScript implementation of libp2p, a modular peer to peer network stack",
   "license": "Apache-2.0 OR MIT",
   "homepage": "https://github.com/libp2p/js-libp2p#readme",

--- a/src/circuit/circuit/hop.ts
+++ b/src/circuit/circuit/hop.ts
@@ -129,7 +129,7 @@ export interface HopConfig extends AbortOptions {
  * Performs a HOP request to a relay peer, to request a connection to another
  * peer. A new, virtual, connection will be created between the two via the relay.
  */
-export async function hop (options: HopConfig): Promise<Duplex<Uint8ArrayList, Uint8ArrayList | Uint8Array>> {
+export async function hop (options: HopConfig): Promise<StreamHandler> {
   const {
     connection,
     request,
@@ -153,7 +153,7 @@ export async function hop (options: HopConfig): Promise<Duplex<Uint8ArrayList, U
   if (response.code === CircuitPB.Status.SUCCESS) {
     log('hop request was successful')
 
-    return streamHandler.rest()
+    return streamHandler
   }
 
   log('hop request failed with code %d, closing stream', response.code)

--- a/src/circuit/circuit/stream-handler.ts
+++ b/src/circuit/circuit/stream-handler.ts
@@ -80,7 +80,7 @@ export class StreamHandler {
    */
   close () {
     log('closing the stream')
-    this.rest().sink([]).catch(err => {
+    void this.rest().sink([]).catch(err => {
       log.error(err)
     })
   }

--- a/src/circuit/circuit/stream-handler.ts
+++ b/src/circuit/circuit/stream-handler.ts
@@ -80,8 +80,6 @@ export class StreamHandler {
    */
   close () {
     log('closing the stream')
-    void this.rest().sink([]).catch(err => {
-      log.error(err)
-    })
+    this.stream.close()
   }
 }

--- a/src/circuit/circuit/stream-handler.ts
+++ b/src/circuit/circuit/stream-handler.ts
@@ -80,6 +80,15 @@ export class StreamHandler {
    */
   close () {
     log('closing the stream')
+    this.rest().sink([]).catch(err => {
+      log.error(err)
+    })
+  }
+
+  /**
+   * Close underlying muxed stream
+   */
+  closeBaseStream  () {
     this.stream.close()
   }
 }

--- a/src/circuit/transport.ts
+++ b/src/circuit/transport.ts
@@ -176,7 +176,7 @@ export class Circuit implements Transport, Startable {
 
         // Overwrite connection close method to close underlying stream
         maConn.close = async () => {
-          streamHandler.close()
+          streamHandler.closeBaseStream()
         }
 
         const conn = await this.components.upgrader.upgradeInbound(maConn)
@@ -248,7 +248,7 @@ export class Circuit implements Transport, Startable {
 
       // Overwrite connection close method to close underlying stream
       maConn.close = async () => {
-        streamHandler.close()
+        streamHandler.closeBaseStream()
       }
 
       return await this.components.upgrader.upgradeOutbound(maConn)

--- a/src/connection-manager/index.ts
+++ b/src/connection-manager/index.ts
@@ -93,6 +93,11 @@ export interface ConnectionManagerConfig {
   resolvers?: Record<string, Resolver>
 
   /**
+   * Boolean to allow multiple connections for a peer after dial
+   */
+  keepMultipleConnections?: boolean
+
+  /**
    * On startup we try to dial any peer that has previously been
    * tagged with KEEP_ALIVE up to this timeout in ms. (default: 60000)
    */


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/289

- Made changes to close underlying muxed stream (with relay node) on closing relayed connection
- Added an option `connectionManager.keepMultipleConnections` for dialling and keeping multiple connections to a peer using different multiaddrs