### PR TITLE
Fix for updating relayed multiaddr after reconnecting with relay node

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/libp2p",
-  "version": "0.42.2-laconic-0.1.0",
+  "version": "0.42.2-laconic-0.1.1",
   "description": "JavaScript implementation of libp2p, a modular peer to peer network stack",
   "license": "Apache-2.0 OR MIT",
   "homepage": "https://github.com/libp2p/js-libp2p#readme",

--- a/src/circuit/circuit/stream-handler.ts
+++ b/src/circuit/circuit/stream-handler.ts
@@ -88,7 +88,7 @@ export class StreamHandler {
   /**
    * Close underlying muxed stream
    */
-  closeBaseStream  () {
+  closeBaseStream () {
     this.stream.close()
   }
 }

--- a/src/connection-manager/dialer/dial-request.ts
+++ b/src/connection-manager/dialer/dial-request.ts
@@ -132,8 +132,7 @@ export class DialRequest {
       // Check for multiple connections option before aborting
       if (!this.keepMultipleConnections) {
         // success/failure happened, abort everything else
-        dialAbortControllers.forEach((c, i) => {
-          console.log('aborting dial index', i, c)
+        dialAbortControllers.forEach(c => {
           if (c !== undefined) {
             c.abort()
           }

--- a/src/connection-manager/dialer/dial-request.ts
+++ b/src/connection-manager/dialer/dial-request.ts
@@ -18,7 +18,7 @@ export interface DialAction {
 export interface DialRequestOptions {
   addrs: Multiaddr[]
   dialAction: DialAction
-  dialer: Dialer,
+  dialer: Dialer
   keepMultipleConnections?: boolean
 }
 

--- a/test/relay/auto-relay.node.ts
+++ b/test/relay/auto-relay.node.ts
@@ -185,6 +185,30 @@ describe('auto-relay', () => {
       })).to.eventually.be.rejected()
     })
 
+    it('should listen again on relayed address after reconnecting used relay node', async () => {
+      // Discover a relay and connect
+      await relayLibp2p1.peerStore.addressBook.add(relayLibp2p2.peerId, relayLibp2p2.getMultiaddrs())
+      await relayLibp2p1.dial(relayLibp2p2.peerId)
+      await discoveredRelayConfig(relayLibp2p1, relayLibp2p2)
+
+      // Wait for listening on the relay
+      await usingAsRelay(relayLibp2p1, relayLibp2p2)
+
+      // Disconnect from peer used for relay
+      await relayLibp2p1.hangUp(relayLibp2p2.peerId)
+
+      // Wait for removed listening on the relay
+      await expect(usingAsRelay(relayLibp2p1, relayLibp2p2, {
+        timeout: 1000
+      })).to.eventually.be.rejected()
+
+      // Reconnect with relay node
+      await relayLibp2p1.dial(relayLibp2p2.peerId)
+
+      // Wait for listening on the relay again
+      await usingAsRelay(relayLibp2p1, relayLibp2p2)
+    })
+
     it('should try to listen on other connected peers relayed address if one used relay disconnects', async () => {
       // Discover one relay and connect
       await relayLibp2p1.peerStore.addressBook.add(relayLibp2p2.peerId, relayLibp2p2.getMultiaddrs())


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/289

- Issue was that peer stops listening on relayed multiaddr after disconnecting from relay node and does not listen again on reconnect
- Fixed by adding handler on `peer:connect` event (`change:protocols` event is not triggered on reconnect) now to listen on relayed multiaddr