### PR TITLE
Handle pubsub error when subscribing to signalling topic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
         "cborg": "^1.8.1",
         "delay": "^5.0.0",
         "execa": "^7.0.0",
-        "go-libp2p": "^0.0.6",
+        "go-libp2p": "^1.1.1",
         "it-to-buffer": "^3.0.1",
         "lodash": "^4.17.21",
         "npm-run-all": "^4.1.5",
@@ -2179,6 +2179,29 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@ipld/dag-pb": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.5.tgz",
+      "integrity": "sha512-El2Jhmv6bWuakhvnw1dl6xOhqLeVhlY8DIAJ06NtZRAoDcOzeGzvOtPzMCszVgCT0EQz+LOctyfgQ5Oszba19A==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/dag-pb/node_modules/multiformats": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -2400,34 +2423,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/crypto/node_modules/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-    },
-    "node_modules/@libp2p/crypto/node_modules/protobufjs": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-      "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@libp2p/crypto/node_modules/protons-runtime": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
@@ -2483,36 +2478,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/daemon-protocol/node_modules/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==",
-      "dev": true
-    },
-    "node_modules/@libp2p/daemon-protocol/node_modules/protobufjs": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-      "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/@libp2p/daemon-protocol/node_modules/protons-runtime": {
@@ -2601,36 +2566,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/floodsub/node_modules/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==",
-      "dev": true
-    },
-    "node_modules/@libp2p/floodsub/node_modules/protobufjs": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-      "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@libp2p/floodsub/node_modules/protons-runtime": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
@@ -2646,6 +2581,20 @@
       },
       "peerDependencies": {
         "uint8arraylist": "^2.3.2"
+      }
+    },
+    "node_modules/@libp2p/interface": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-0.1.2.tgz",
+      "integrity": "sha512-Q5t27434Mvn+R6AUJlRH+q/jSXarDpP+KXVkyGY7S1fKPI2berqoFPqT61bRRBYsCH2OPZiKBB53VUzxL9uEvg==",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.1.5",
+        "abortable-iterator": "^5.0.1",
+        "it-pushable": "^3.2.0",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^12.0.1",
+        "p-defer": "^4.0.0",
+        "uint8arraylist": "^2.4.3"
       }
     },
     "node_modules/@libp2p/interface-address-manager": {
@@ -2994,9 +2943,9 @@
       }
     },
     "node_modules/@libp2p/interface-peer-id": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
-      "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+      "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
       "dependencies": {
         "multiformats": "^11.0.0"
       },
@@ -3174,10 +3123,68 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@libp2p/interface/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.7.tgz",
+      "integrity": "sha512-MZRj+uUrtF2WqgByrsPolrdyPDSFstw7Fe0ewabWgWl27fcOmfDOSrEt2aUVkSzapXbyCG7JQh0QvimmTF4aMA==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interface": "^0.1.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^12.0.1",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.6.0"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/abortable-iterator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-5.0.1.tgz",
+      "integrity": "sha512-hlZ5Z8UwqrKsJcelVPEqDduZowJPBQJ9ZhBC2FXpja3lXy8X6MoI5uMzIgmrA8+3jcVnp8TF/tx+IBBqYJNUrg==",
+      "dependencies": {
+        "get-iterator": "^2.0.0",
+        "it-stream-types": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/it-stream-types": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+      "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/multiformats": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/uint8-varint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.1.tgz",
+      "integrity": "sha512-euvmpuulJstK5+xNuI4S1KfnxJnbI5QP52RXIR3GZ3/ZMkOsEK2AgCtFpNvEQLXMxMx2o0qcyevK1fJwOZJagQ==",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      }
+    },
     "node_modules/@libp2p/interfaces": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
-      "integrity": "sha512-3N+goQt74SmaVOjwpwMPKLNgh1uDQGw8GD12c40Kc86WOq0qvpm3NfACW+H8Su2X6KmWjCSMzk9JWs9+8FtUfg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.2.tgz",
+      "integrity": "sha512-p/M7plbrxLzuQchvNwww1Was7ZeGE2NaOFulMaZBYIihU8z3fhaV+a033OqnC/0NTX/yhfdNOG7znhYq3XoR/g==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -3263,36 +3270,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/kad-dht/node_modules/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==",
-      "dev": true
-    },
-    "node_modules/@libp2p/kad-dht/node_modules/protobufjs": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-      "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@libp2p/kad-dht/node_modules/protons-runtime": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
@@ -3332,15 +3309,43 @@
       }
     },
     "node_modules/@libp2p/logger": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.6.tgz",
-      "integrity": "sha512-PfTGCBT6buiGeww7heG1JucBK2io2sJ2hntNh+gTVohRy4FyEvZixnWfIVD2rCM8EsbZu3Hmt/qqetzX5BrziQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.1.1.tgz",
+      "integrity": "sha512-2UbzDPctg3cPupF6jrv6abQnAUTrbLybNOj0rmmrdGm1cN2HJ1o/hBu0sXuq4KF9P1h/eVRn1HIRbVIEKnEJrA==",
       "dependencies": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "debug": "^4.3.3",
-        "interface-datastore": "^8.0.0",
-        "multiformats": "^11.0.0"
+        "@libp2p/interface-peer-id": "^2.0.2",
+        "@multiformats/multiaddr": "^12.1.3",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^11.0.2"
       },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.7.tgz",
+      "integrity": "sha512-MZRj+uUrtF2WqgByrsPolrdyPDSFstw7Fe0ewabWgWl27fcOmfDOSrEt2aUVkSzapXbyCG7JQh0QvimmTF4aMA==",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interface": "^0.1.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^12.0.1",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.6.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/@multiformats/multiaddr/node_modules/multiformats": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -3367,6 +3372,15 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@libp2p/logger/node_modules/uint8-varint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.1.tgz",
+      "integrity": "sha512-euvmpuulJstK5+xNuI4S1KfnxJnbI5QP52RXIR3GZ3/ZMkOsEK2AgCtFpNvEQLXMxMx2o0qcyevK1fJwOZJagQ==",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
       }
     },
     "node_modules/@libp2p/mdns": {
@@ -3490,34 +3504,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/peer-id-factory/node_modules/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-    },
-    "node_modules/@libp2p/peer-id-factory/node_modules/protobufjs": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-      "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@libp2p/peer-id-factory/node_modules/protons-runtime": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
@@ -3574,34 +3560,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/@libp2p/peer-record/node_modules/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-    },
-    "node_modules/@libp2p/peer-record/node_modules/protobufjs": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-      "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@libp2p/peer-record/node_modules/protons-runtime": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
@@ -3646,34 +3604,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-store/node_modules/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-    },
-    "node_modules/@libp2p/peer-store/node_modules/protobufjs": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-      "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/@libp2p/peer-store/node_modules/protons-runtime": {
@@ -3738,36 +3668,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@libp2p/record/node_modules/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==",
-      "dev": true
-    },
-    "node_modules/@libp2p/record/node_modules/protobufjs": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-      "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/@libp2p/record/node_modules/protons-runtime": {
@@ -3999,12 +3899,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@multiformats/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==",
-      "dev": true
-    },
     "node_modules/@multiformats/mafmt": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-11.1.2.tgz",
@@ -4079,6 +3973,30 @@
         "uint8arrays": "^4.0.2",
         "varint": "^6.0.0"
       },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/murmur3": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.6.tgz",
+      "integrity": "sha512-kpJDN+o8B0gJaaqbdV/spIVPj35hqew4rEw8VzPmcITsLpHSgP8pJDeaVaGGVeX/UM8n4IGctLCxw7PBfVks+A==",
+      "dev": true,
+      "dependencies": {
+        "multiformats": "^12.0.1",
+        "murmurhash3js-revisited": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/murmur3/node_modules/multiformats": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
+      "dev": true,
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -5305,12 +5223,6 @@
       "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
       "dev": true
     },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "dev": true
-    },
     "node_modules/@types/mdast": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
@@ -6478,11 +6390,128 @@
         "node": ">= 6"
       }
     },
-    "node_modules/blakejs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+    "node_modules/blockstore-core": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/blockstore-core/-/blockstore-core-4.3.3.tgz",
+      "integrity": "sha512-+CyaLkkI7fUKCV/zTQTUmRjejgl1cyynjMZtoeYMXzp/024oy7HlUQZbcoLjxiqzlejMq2S4LD0iyRae2k67+g==",
+      "dev": true,
+      "dependencies": {
+        "@libp2p/logger": "^3.0.0",
+        "err-code": "^3.0.1",
+        "interface-blockstore": "^5.0.0",
+        "interface-store": "^5.0.0",
+        "it-drain": "^3.0.1",
+        "it-filter": "^3.0.0",
+        "it-merge": "^3.0.1",
+        "it-pushable": "^3.0.0",
+        "multiformats": "^12.0.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/@libp2p/logger": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.0.2.tgz",
+      "integrity": "sha512-2JtRGBXiGfm1t5XneUIXQ2JusW7QwyYmxsW7hSAYS5J73RQJUicpt5le5obVRt7+OM39ei+nWEuC6Xvm1ugHkw==",
+      "dev": true,
+      "dependencies": {
+        "@libp2p/interface": "^0.1.2",
+        "@multiformats/multiaddr": "^12.1.5",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^12.0.1"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/@multiformats/multiaddr": {
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.7.tgz",
+      "integrity": "sha512-MZRj+uUrtF2WqgByrsPolrdyPDSFstw7Fe0ewabWgWl27fcOmfDOSrEt2aUVkSzapXbyCG7JQh0QvimmTF4aMA==",
+      "dev": true,
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/interface": "^0.1.1",
+        "dns-over-http-resolver": "^2.1.0",
+        "multiformats": "^12.0.1",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.6.0"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/interface-datastore": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.4.tgz",
+      "integrity": "sha512-5ng8eSfuynvywa6/5FHbYdyBMrzMdRqcH+xk48hZMr1F+wmLM5Qkh9QuLtYIlTkpUn5INB4vNBONC+swHiLgpA==",
+      "dev": true,
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "nanoid": "^4.0.0",
+        "uint8arrays": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/interface-store": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.3.tgz",
+      "integrity": "sha512-zAarfBW08mhReqsWy1f6R3aoCmYOkxBH6LONugVtM6d9mmcmqpoYmMnIRoLmM1jtCuP9/OvSvL4kJio1TCWREw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/it-drain": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-3.0.3.tgz",
+      "integrity": "sha512-l4s+izxUpFAR2axprpFiCaq0EtxK1QMd0LWbEtau5b+OegiZ5xdRtz35iJyh6KZY9QtuwEiQxydiOfYJc7stoA==",
       "dev": true
+    },
+    "node_modules/blockstore-core/node_modules/it-filter": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.0.3.tgz",
+      "integrity": "sha512-2zXUrJuuV6QHM21ahc8NqVUUxkLMVDWXBoUBcj9GCQLQez2OXmddTHN0r0F5B+TkNTpeL618yIgXi1HNPJOxow==",
+      "dev": true,
+      "dependencies": {
+        "it-peekable": "^3.0.0"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/it-merge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.2.tgz",
+      "integrity": "sha512-bMk2km8lTz+Rwv30hzDUdGIcqQkOemFJqmGT2wqQZ6/zHKCsYqdRunPrteCqHLV/nIVhUK8nZZkDA2eJ4MJZiA==",
+      "dev": true,
+      "dependencies": {
+        "it-pushable": "^3.2.0"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/multiformats": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/blockstore-core/node_modules/uint8-varint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.1.tgz",
+      "integrity": "sha512-euvmpuulJstK5+xNuI4S1KfnxJnbI5QP52RXIR3GZ3/ZMkOsEK2AgCtFpNvEQLXMxMx2o0qcyevK1fJwOZJagQ==",
+      "dev": true,
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^4.0.2"
+      }
     },
     "node_modules/boolean": {
       "version": "3.2.0",
@@ -7287,38 +7316,6 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
-    },
-    "node_modules/cids": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.9.tgz",
-      "integrity": "sha512-l11hWRfugIcbGuTZwAM5PwpjPPjyb6UZOGwlHSnOBV5o07XhQ4gNpBN67FbODvpjyHtd+0Xs6KNvUcGBiDRsdg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dev": true,
-      "dependencies": {
-        "multibase": "^4.0.1",
-        "multicodec": "^3.0.1",
-        "multihashes": "^4.0.1",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
-    "node_modules/cids/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-      "dev": true
-    },
-    "node_modules/cids/node_modules/uint8arrays": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-      "dev": true,
-      "dependencies": {
-        "multiformats": "^9.4.2"
-      }
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -11078,22 +11075,193 @@
       }
     },
     "node_modules/go-libp2p": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/go-libp2p/-/go-libp2p-0.0.6.tgz",
-      "integrity": "sha512-zt11CiU29EPFnlPBmZ5wnGmhi7hzj1qJLhainTbtTqMiFeqqCeJE6E7K6B/0n+EEF0aIeanqelughcWNzZr7Mw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/go-libp2p/-/go-libp2p-1.1.1.tgz",
+      "integrity": "sha512-dSyteUFY1T+8PllfS1wDzyi0uPxapaIAQfwoo39nUZMKqo08NtPxTPI/3oVwIIP1cX5jZuJUXVMDjCGW/3Vqdg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
+        "blockstore-core": "^4.2.0",
         "cachedir": "^2.3.0",
-        "got": "^11.7.0",
+        "delay": "^6.0.0",
+        "got": "^12.5.3",
         "gunzip-maybe": "^1.4.2",
-        "ipfs-only-hash": "^4.0.0",
-        "pkg-conf": "^3.1.0",
+        "ipfs-unixfs-importer": "^15.1.5",
+        "it-last": "^3.0.2",
+        "multiformats": "^11.0.2",
+        "p-retry": "^5.1.2",
+        "pkg-conf": "^4.0.0",
         "tar-fs": "^2.1.0",
+        "uint8arrays": "^4.0.3",
         "unzip-stream": "^0.3.0"
       },
       "bin": {
         "go-libp2p": "bin/p2pd"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/go-libp2p/node_modules/@sindresorhus/is": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/go-libp2p/node_modules/@szmarczak/http-timer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+      "dev": true,
+      "dependencies": {
+        "defer-to-connect": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/go-libp2p/node_modules/cacheable-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/go-libp2p/node_modules/cacheable-request": {
+      "version": "10.2.13",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.13.tgz",
+      "integrity": "sha512-3SD4rrMu1msNGEtNSt8Od6enwdo//U9s4ykmXfA2TD58kcLkCobtCDiby7kNyj7a/Q7lz/mAesAFI54rTdnvBA==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-cache-semantics": "^4.0.1",
+        "get-stream": "^6.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "keyv": "^4.5.3",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/go-libp2p/node_modules/delay": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-6.0.0.tgz",
+      "integrity": "sha512-2NJozoOHQ4NuZuVIr5CWd0iiLVIRSDepakaovIN+9eIDHEhdCAEvSy2cuf1DCrPPQLvHmbqTHODlhHg8UCy4zw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/go-libp2p/node_modules/got": {
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
+      "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
+      "dev": true,
+      "dependencies": {
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.8",
+        "decompress-response": "^6.0.0",
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/go-libp2p/node_modules/http2-wrapper": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
+      "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
+      "dev": true,
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/go-libp2p/node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/go-libp2p/node_modules/mimic-response": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/go-libp2p/node_modules/normalize-url": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+      "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/go-libp2p/node_modules/p-cancelable": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/go-libp2p/node_modules/responselike": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+      "dev": true,
+      "dependencies": {
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -11182,32 +11350,17 @@
       }
     },
     "node_modules/hamt-sharding": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
-      "integrity": "sha512-vnjrmdXG9dDs1m/H4iJ6z0JFI2NtgsW5keRkTcM85NGak69Mkf5PHUqBz+Xs0T4sg0ppvj9O5EGAJo40FTxmmA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-3.0.2.tgz",
+      "integrity": "sha512-f0DzBD2tSmLFdFsLAvOflIBqFPjerbA7BfmwO8mVho/5hXwgyyYhv+ijIzidQf/DpDX3bRjAQvhGoBFj+DBvPw==",
       "dev": true,
       "dependencies": {
         "sparse-array": "^1.3.1",
-        "uint8arrays": "^3.0.0"
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
-        "node": ">=10.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/hamt-sharding/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-      "dev": true
-    },
-    "node_modules/hamt-sharding/node_modules/uint8arrays": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-      "dev": true,
-      "dependencies": {
-        "multiformats": "^9.4.2"
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/handlebars": {
@@ -11615,6 +11768,40 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
+    "node_modules/interface-blockstore": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-5.2.5.tgz",
+      "integrity": "sha512-xqu9/8Q3spKUe21eLl7+AGFlzsWZxMNKwvbTJdYJIenG3pL4QKlZQl18RNzVVzMK8GXOgDWDe8gSIP/rldHJAg==",
+      "dev": true,
+      "dependencies": {
+        "interface-store": "^5.0.0",
+        "multiformats": "^12.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/interface-blockstore/node_modules/interface-store": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.3.tgz",
+      "integrity": "sha512-zAarfBW08mhReqsWy1f6R3aoCmYOkxBH6LONugVtM6d9mmcmqpoYmMnIRoLmM1jtCuP9/OvSvL4kJio1TCWREw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/interface-blockstore/node_modules/multiformats": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/interface-datastore": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
@@ -11627,18 +11814,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/interface-ipld-format": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/interface-ipld-format/-/interface-ipld-format-1.0.1.tgz",
-      "integrity": "sha512-WV/ar+KQJVoQpqRDYdo7YPGYIUHJxCuOEhdvsRpzLqoOIVCqPKdMMYmsLL1nCRsF3yYNio+PAJbCKiv6drrEAg==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dev": true,
-      "dependencies": {
-        "cids": "^1.1.6",
-        "multicodec": "^3.0.1",
-        "multihashes": "^4.0.2"
       }
     },
     "node_modules/interface-store": {
@@ -11708,232 +11883,92 @@
         "node": ">= 10"
       }
     },
-    "node_modules/ipfs-only-hash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ipfs-only-hash/-/ipfs-only-hash-4.0.0.tgz",
-      "integrity": "sha512-TE1DZCvfw8i3gcsTq3P4TFx3cKFJ3sluu/J3XINkJhIN9OwJgNMqKA+WnKx6ByCb1IoPXsTp1KM7tupElb6SyA==",
-      "dev": true,
-      "dependencies": {
-        "ipfs-unixfs-importer": "^7.0.1",
-        "meow": "^9.0.0"
-      },
-      "bin": {
-        "ipfs-only-hash": "cli.js"
-      }
-    },
-    "node_modules/ipfs-only-hash/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ipfs-only-hash/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ipfs-only-hash/node_modules/meow": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize": "^1.2.0",
-        "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.1.0",
-        "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.18.0",
-        "yargs-parser": "^20.2.3"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ipfs-only-hash/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ipfs-only-hash/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ipfs-only-hash/node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ipfs-only-hash/node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ipfs-only-hash/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ipfs-unixfs": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-4.0.3.tgz",
-      "integrity": "sha512-hzJ3X4vlKT8FQ3Xc4M1szaFVjsc1ZydN+E4VQ91aXxfpjFn9G2wsMo1EFdAXNq/BUnN5dgqIOMP5zRYr3DTsAw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.1.0.tgz",
+      "integrity": "sha512-Lq37nKLJOpRFjx3rcg3y+ZwUxBX7jluKfIt5UPp6wb1L3dP0sj1yaLR0Yg2CdGYvHWyUpZD1iTnT8upL0ToDOw==",
       "dev": true,
       "dependencies": {
         "err-code": "^3.0.1",
-        "protobufjs": "^6.10.2"
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3"
       },
       "engines": {
-        "node": ">=14.0.0",
+        "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/ipfs-unixfs-importer": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-7.0.3.tgz",
-      "integrity": "sha512-qeFOlD3AQtGzr90sr5Tq1Bi8pT5Nr2tSI8z310m7R4JDYgZc6J1PEZO3XZQ8l1kuGoqlAppBZuOYmPEqaHcVQQ==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-15.2.1.tgz",
+      "integrity": "sha512-9ArBh7Xfz8gUSe8pq9c9ilBOXd1bbT3L+4xnI6w/usWLwnNT14p8WbFZjDD0MO1/PrD0PTUZuHNDS2l4EO+wPg==",
       "dev": true,
       "dependencies": {
-        "bl": "^5.0.0",
-        "cids": "^1.1.5",
+        "@ipld/dag-pb": "^4.0.0",
+        "@multiformats/murmur3": "^2.0.0",
         "err-code": "^3.0.1",
-        "hamt-sharding": "^2.0.0",
-        "ipfs-unixfs": "^4.0.3",
-        "ipld-dag-pb": "^0.22.2",
-        "it-all": "^1.0.5",
-        "it-batch": "^1.0.8",
-        "it-first": "^1.0.6",
-        "it-parallel-batch": "^1.0.9",
-        "merge-options": "^3.0.4",
-        "multihashing-async": "^2.1.0",
+        "hamt-sharding": "^3.0.0",
+        "interface-blockstore": "^5.0.0",
+        "interface-store": "^5.0.1",
+        "ipfs-unixfs": "^11.0.0",
+        "it-all": "^3.0.2",
+        "it-batch": "^3.0.2",
+        "it-first": "^3.0.2",
+        "it-parallel-batch": "^3.0.1",
+        "multiformats": "^12.0.1",
+        "progress-events": "^1.0.0",
         "rabin-wasm": "^0.1.4",
-        "uint8arrays": "^2.1.2"
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.2"
       },
       "engines": {
-        "node": ">=14.0.0",
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/ipfs-unixfs-importer/node_modules/interface-store": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.3.tgz",
+      "integrity": "sha512-zAarfBW08mhReqsWy1f6R3aoCmYOkxBH6LONugVtM6d9mmcmqpoYmMnIRoLmM1jtCuP9/OvSvL4kJio1TCWREw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/ipfs-unixfs-importer/node_modules/it-all": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
-      "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+      "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A==",
       "dev": true
     },
     "node_modules/ipfs-unixfs-importer/node_modules/it-first": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
-      "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.3.tgz",
+      "integrity": "sha512-RC8tplctsDpoBUljwsp1viiyaR5fPvMe+FgbbcU0sFjKkJa7iwbB4CCPhHtVYSdjsrREfr0QEotfQrBoGyt7Dw==",
       "dev": true
     },
     "node_modules/ipfs-unixfs-importer/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-      "dev": true
-    },
-    "node_modules/ipfs-unixfs-importer/node_modules/uint8arrays": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
-      "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+      "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
       "dev": true,
-      "dependencies": {
-        "multiformats": "^9.4.2"
-      }
-    },
-    "node_modules/ipld-dag-pb": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.22.3.tgz",
-      "integrity": "sha512-dfG5C5OVAR4FEP7Al2CrHWvAyIM7UhAQrjnOYOIxXGQz5NlEj6wGX0XQf6Ru6or1na6upvV3NQfstapQG8X2rg==",
-      "deprecated": "This module has been superseded by @ipld/dag-pb and multiformats",
-      "dev": true,
-      "dependencies": {
-        "cids": "^1.0.0",
-        "interface-ipld-format": "^1.0.0",
-        "multicodec": "^3.0.1",
-        "multihashing-async": "^2.0.0",
-        "protobufjs": "^6.10.2",
-        "stable": "^0.1.8",
-        "uint8arrays": "^2.0.5"
-      },
       "engines": {
-        "node": ">=6.0.0",
-        "npm": ">=3.0.0"
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
       }
     },
-    "node_modules/ipld-dag-pb/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-      "dev": true
-    },
-    "node_modules/ipld-dag-pb/node_modules/uint8arrays": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
-      "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
+    "node_modules/ipfs-unixfs/node_modules/protons-runtime": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.2.tgz",
+      "integrity": "sha512-eKppVrIS5dDh+Y61Yj4bDEOs2sQLQbQGIhr7EBiybPQhIMGBynzVXlYILPWl3Td1GDadobc8qevh5D+JwfG9bw==",
       "dev": true,
       "dependencies": {
-        "multiformats": "^9.4.2"
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "peerDependencies": {
+        "uint8arraylist": "^2.3.2"
       }
     },
     "node_modules/irregular-plurals": {
@@ -12740,9 +12775,9 @@
       }
     },
     "node_modules/it-batch": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.9.tgz",
-      "integrity": "sha512-7Q7HXewMhNFltTsAMdSz6luNhyhkhEtGGbYek/8Xb/GiqYMtwUmopE1ocPSiJKKp3rM4Dt045sNFoUu+KZGNyA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-3.0.3.tgz",
+      "integrity": "sha512-KdKVGOZgYhxiHTMphzPKaiNL99yyUgeDoqRmSedbKJr05nP5RxtiIPWX+i1dLCADRjExbGtKfFsrogNgH0h9SA==",
       "dev": true
     },
     "node_modules/it-batched-bytes": {
@@ -12811,6 +12846,12 @@
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
       }
+    },
+    "node_modules/it-last": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-3.0.3.tgz",
+      "integrity": "sha512-veF0zWTMEJ466Otxz7jPbExiJGfJYTOiHYGfg8iGwKPIV558zIGZQJU1WNyjHfugFzAyfuFlIZKsXCCtCl8LgQ==",
+      "dev": true
     },
     "node_modules/it-length": {
       "version": "2.0.1",
@@ -12896,12 +12937,12 @@
       }
     },
     "node_modules/it-parallel-batch": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.11.tgz",
-      "integrity": "sha512-UWsWHv/kqBpMRmyZJzlmZeoAMA0F3SZr08FBdbhtbe+MtoEBgr/ZUAKrnenhXCBrsopy76QjRH2K/V8kNdupbQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-3.0.2.tgz",
+      "integrity": "sha512-8ci62F5gn5aS8/wEC0kvRKWCmenHlIi+R8waEF/SP1ImQhhkve9l4/DXEmoL7UeI5FqJktzkMzZwqDng0ZppKw==",
       "dev": true,
       "dependencies": {
-        "it-batch": "^1.0.9"
+        "it-batch": "^3.0.0"
       }
     },
     "node_modules/it-pb-stream": {
@@ -12920,6 +12961,12 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/it-peekable": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+      "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA==",
+      "dev": true
+    },
     "node_modules/it-pipe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
@@ -12935,9 +12982,12 @@
       }
     },
     "node_modules/it-pushable": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.2.tgz",
-      "integrity": "sha512-zU9FbeoGT0f+yobwm8agol2OTMXbq4ZSWLEi7hug6TEZx4qVhGhGyp31cayH04aBYsIoO2Nr5kgMjH/oWj2BJQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.1.tgz",
+      "integrity": "sha512-sLFz2Q0oyDCJpTciZog7ipP4vSftfPy3e6JnH6YyztRa1XqkpGQaafK3Jw/JlfEBtCXfnX9uVfcpu3xpSAqCVQ==",
+      "dependencies": {
+        "p-defer": "^4.0.0"
+      },
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
@@ -13034,12 +13084,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
       }
-    },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-      "dev": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -13205,9 +13249,9 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
       "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -13444,50 +13488,15 @@
       }
     },
     "node_modules/load-json-file": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
-      "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-7.0.1.tgz",
+      "integrity": "sha512-Gnxj3ev3mB5TkVBGad0JM6dmLiQL+o0t23JPBZ9sd+yvSLk05mFoqKBw5N8gbbkU4TNXyqCgIrl/VM17OgUIgQ==",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.15",
-        "parse-json": "^4.0.0",
-        "pify": "^4.0.1",
-        "strip-bom": "^3.0.0",
-        "type-fest": "^0.3.0"
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/load-json-file/node_modules/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-      "dev": true,
-      "dependencies": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/load-json-file/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/load-json-file/node_modules/type-fest": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/locate-path": {
@@ -13659,10 +13668,9 @@
       }
     },
     "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "dev": true
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/longbits": {
       "version": "1.1.0",
@@ -15374,20 +15382,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/multibase": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-      "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dev": true,
-      "dependencies": {
-        "@multiformats/base-x": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
@@ -15401,32 +15395,6 @@
         "multicast-dns": "cli.js"
       }
     },
-    "node_modules/multicodec": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.2.1.tgz",
-      "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
-      "deprecated": "This module has been superseded by the multiformats module",
-      "dev": true,
-      "dependencies": {
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
-      }
-    },
-    "node_modules/multicodec/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-      "dev": true
-    },
-    "node_modules/multicodec/node_modules/uint8arrays": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-      "dev": true,
-      "dependencies": {
-        "multiformats": "^9.4.2"
-      }
-    },
     "node_modules/multiformats": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
@@ -15434,75 +15402,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/multihashes": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-      "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-      "dev": true,
-      "dependencies": {
-        "multibase": "^4.0.1",
-        "uint8arrays": "^3.0.0",
-        "varint": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/multihashes/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-      "dev": true
-    },
-    "node_modules/multihashes/node_modules/uint8arrays": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-      "dev": true,
-      "dependencies": {
-        "multiformats": "^9.4.2"
-      }
-    },
-    "node_modules/multihashes/node_modules/varint": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-      "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
-      "dev": true
-    },
-    "node_modules/multihashing-async": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.1.4.tgz",
-      "integrity": "sha512-sB1MiQXPSBTNRVSJc2zM157PXgDtud2nMFUEIvBrsq5Wv96sUclMRK/ecjoP1T/W61UJBqt4tCTwMkUpt2Gbzg==",
-      "dev": true,
-      "dependencies": {
-        "blakejs": "^1.1.0",
-        "err-code": "^3.0.0",
-        "js-sha3": "^0.8.0",
-        "multihashes": "^4.0.1",
-        "murmurhash3js-revisited": "^3.0.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
-    "node_modules/multihashing-async/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-      "dev": true
-    },
-    "node_modules/multihashing-async/node_modules/uint8arrays": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-      "dev": true,
-      "dependencies": {
-        "multiformats": "^9.4.2"
       }
     },
     "node_modules/multimatch": {
@@ -20379,15 +20278,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
@@ -20410,77 +20300,101 @@
       }
     },
     "node_modules/pkg-conf": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
-      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-4.0.0.tgz",
+      "integrity": "sha512-7dmgi4UY4qk+4mj5Cd8v/GExPo0K+SlY+hulOSdfZ/T6jVH6//y7NtzZo5WrfhDBxuQ0jCa7fLZmNaNh7EWL/w==",
       "dev": true,
       "dependencies": {
-        "find-up": "^3.0.0",
-        "load-json-file": "^5.2.0"
+        "find-up": "^6.0.0",
+        "load-json-file": "^7.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pkg-conf/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
       "dev": true,
       "dependencies": {
-        "locate-path": "^3.0.0"
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pkg-conf/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
       "dev": true,
       "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "^6.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pkg-conf/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
       "dev": true,
       "dependencies": {
-        "p-try": "^2.0.0"
+        "yocto-queue": "^1.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pkg-conf/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
       "dev": true,
       "dependencies": {
-        "p-limit": "^2.0.0"
+        "p-limit": "^4.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pkg-conf/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
       "dev": true,
       "engines": {
-        "node": ">=4"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/pkg-conf/node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/pkg-dir": {
@@ -21283,6 +21197,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/progress-events": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.0.tgz",
+      "integrity": "sha512-zIB6QDrSbPfRg+33FZalluFIowkbV5Xh1xSuetjG+rlC5he6u2dc6VQJ0TbMdlN3R1RHdpOqxEFMKTnQ+itUwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
     "node_modules/prompt": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.3.0.tgz",
@@ -21332,56 +21256,9 @@
       "dev": true
     },
     "node_modules/protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
-    },
-    "node_modules/protons-runtime": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-4.0.2.tgz",
-      "integrity": "sha512-R4N6qKHgz8T2Gl45CTcZfITzXPQY9ym8lbLb4VyFMS4ag1KusCRZwkQXTBRhxQ+93ck3K3aDhK1wIk98AMtNyw==",
-      "dependencies": {
-        "protobufjs": "^7.0.0",
-        "uint8arraylist": "^2.4.3"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      },
-      "peerDependencies": {
-        "uint8arraylist": "^2.3.2"
-      }
-    },
-    "node_modules/protons-runtime/node_modules/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-    },
-    "node_modules/protons-runtime/node_modules/protobufjs": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-      "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -21399,6 +21276,22 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/protons-runtime": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-4.0.2.tgz",
+      "integrity": "sha512-R4N6qKHgz8T2Gl45CTcZfITzXPQY9ym8lbLb4VyFMS4ag1KusCRZwkQXTBRhxQ+93ck3K3aDhK1wIk98AMtNyw==",
+      "dependencies": {
+        "protobufjs": "^7.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      },
+      "peerDependencies": {
+        "uint8arraylist": "^2.3.2"
       }
     },
     "node_modules/pseudomap": {
@@ -23906,13 +23799,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
-    },
-    "node_modules/stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
-      "dev": true
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -27742,6 +27628,23 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@ipld/dag-pb": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-pb/-/dag-pb-4.0.5.tgz",
+      "integrity": "sha512-El2Jhmv6bWuakhvnw1dl6xOhqLeVhlY8DIAJ06NtZRAoDcOzeGzvOtPzMCszVgCT0EQz+LOctyfgQ5Oszba19A==",
+      "dev": true,
+      "requires": {
+        "multiformats": "^12.0.1"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+          "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
+          "dev": true
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -27915,30 +27818,6 @@
         "uint8arrays": "^4.0.2"
       },
       "dependencies": {
-        "long": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-          "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-        },
-        "protobufjs": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-          "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
-          }
-        },
         "protons-runtime": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
@@ -27983,32 +27862,6 @@
         "uint8arraylist": "^2.3.2"
       },
       "dependencies": {
-        "long": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-          "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==",
-          "dev": true
-        },
-        "protobufjs": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-          "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-          "dev": true,
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
-          }
-        },
         "protons-runtime": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
@@ -28080,32 +27933,6 @@
         "uint8arrays": "^4.0.3"
       },
       "dependencies": {
-        "long": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-          "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==",
-          "dev": true
-        },
-        "protobufjs": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-          "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-          "dev": true,
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
-          }
-        },
         "protons-runtime": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
@@ -28114,6 +27941,64 @@
           "requires": {
             "protobufjs": "^7.0.0",
             "uint8arraylist": "^2.4.3"
+          }
+        }
+      }
+    },
+    "@libp2p/interface": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-0.1.2.tgz",
+      "integrity": "sha512-Q5t27434Mvn+R6AUJlRH+q/jSXarDpP+KXVkyGY7S1fKPI2berqoFPqT61bRRBYsCH2OPZiKBB53VUzxL9uEvg==",
+      "requires": {
+        "@multiformats/multiaddr": "^12.1.5",
+        "abortable-iterator": "^5.0.1",
+        "it-pushable": "^3.2.0",
+        "it-stream-types": "^2.0.1",
+        "multiformats": "^12.0.1",
+        "p-defer": "^4.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "12.1.7",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.7.tgz",
+          "integrity": "sha512-MZRj+uUrtF2WqgByrsPolrdyPDSFstw7Fe0ewabWgWl27fcOmfDOSrEt2aUVkSzapXbyCG7JQh0QvimmTF4aMA==",
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "@chainsafe/netmask": "^2.0.0",
+            "@libp2p/interface": "^0.1.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "multiformats": "^12.0.1",
+            "uint8-varint": "^2.0.1",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "abortable-iterator": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/abortable-iterator/-/abortable-iterator-5.0.1.tgz",
+          "integrity": "sha512-hlZ5Z8UwqrKsJcelVPEqDduZowJPBQJ9ZhBC2FXpja3lXy8X6MoI5uMzIgmrA8+3jcVnp8TF/tx+IBBqYJNUrg==",
+          "requires": {
+            "get-iterator": "^2.0.0",
+            "it-stream-types": "^2.0.1"
+          }
+        },
+        "it-stream-types": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/it-stream-types/-/it-stream-types-2.0.1.tgz",
+          "integrity": "sha512-6DmOs5r7ERDbvS4q8yLKENcj6Yecr7QQTqWApbZdfAUTEC947d+PEha7PCqhm//9oxaLYL7TWRekwhoXl2s6fg=="
+        },
+        "multiformats": {
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+          "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ=="
+        },
+        "uint8-varint": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.1.tgz",
+          "integrity": "sha512-euvmpuulJstK5+xNuI4S1KfnxJnbI5QP52RXIR3GZ3/ZMkOsEK2AgCtFpNvEQLXMxMx2o0qcyevK1fJwOZJagQ==",
+          "requires": {
+            "uint8arraylist": "^2.0.0",
+            "uint8arrays": "^4.0.2"
           }
         }
       }
@@ -28394,9 +28279,9 @@
       }
     },
     "@libp2p/interface-peer-id": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.1.tgz",
-      "integrity": "sha512-k01hKHTAZWMOiBC+yyFsmBguEMvhPkXnQtqLtFqga2fVZu8Zve7zFAtQYLhQjeJ4/apeFtO6ddTS8mCE6hl4OA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-peer-id/-/interface-peer-id-2.0.2.tgz",
+      "integrity": "sha512-9pZp9zhTDoVwzRmp0Wtxw0Yfa//Yc0GqBCJi3EznBDE6HGIAVvppR91wSh2knt/0eYg0AQj7Y35VSesUTzMCUg==",
       "requires": {
         "multiformats": "^11.0.0"
       }
@@ -28533,9 +28418,9 @@
       }
     },
     "@libp2p/interfaces": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.1.tgz",
-      "integrity": "sha512-3N+goQt74SmaVOjwpwMPKLNgh1uDQGw8GD12c40Kc86WOq0qvpm3NfACW+H8Su2X6KmWjCSMzk9JWs9+8FtUfg=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/interfaces/-/interfaces-3.3.2.tgz",
+      "integrity": "sha512-p/M7plbrxLzuQchvNwww1Was7ZeGE2NaOFulMaZBYIihU8z3fhaV+a033OqnC/0NTX/yhfdNOG7znhYq3XoR/g=="
     },
     "@libp2p/interop": {
       "version": "5.0.0",
@@ -28606,32 +28491,6 @@
         "varint": "^6.0.0"
       },
       "dependencies": {
-        "long": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-          "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==",
-          "dev": true
-        },
-        "protobufjs": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-          "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-          "dev": true,
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
-          }
-        },
         "protons-runtime": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
@@ -28662,16 +28521,38 @@
       }
     },
     "@libp2p/logger": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.0.6.tgz",
-      "integrity": "sha512-PfTGCBT6buiGeww7heG1JucBK2io2sJ2hntNh+gTVohRy4FyEvZixnWfIVD2rCM8EsbZu3Hmt/qqetzX5BrziQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-2.1.1.tgz",
+      "integrity": "sha512-2UbzDPctg3cPupF6jrv6abQnAUTrbLybNOj0rmmrdGm1cN2HJ1o/hBu0sXuq4KF9P1h/eVRn1HIRbVIEKnEJrA==",
       "requires": {
-        "@libp2p/interface-peer-id": "^2.0.0",
-        "debug": "^4.3.3",
-        "interface-datastore": "^8.0.0",
-        "multiformats": "^11.0.0"
+        "@libp2p/interface-peer-id": "^2.0.2",
+        "@multiformats/multiaddr": "^12.1.3",
+        "debug": "^4.3.4",
+        "interface-datastore": "^8.2.0",
+        "multiformats": "^11.0.2"
       },
       "dependencies": {
+        "@multiformats/multiaddr": {
+          "version": "12.1.7",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.7.tgz",
+          "integrity": "sha512-MZRj+uUrtF2WqgByrsPolrdyPDSFstw7Fe0ewabWgWl27fcOmfDOSrEt2aUVkSzapXbyCG7JQh0QvimmTF4aMA==",
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "@chainsafe/netmask": "^2.0.0",
+            "@libp2p/interface": "^0.1.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "multiformats": "^12.0.1",
+            "uint8-varint": "^2.0.1",
+            "uint8arrays": "^4.0.2"
+          },
+          "dependencies": {
+            "multiformats": {
+              "version": "12.1.0",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+              "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ=="
+            }
+          }
+        },
         "interface-datastore": {
           "version": "8.2.0",
           "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.0.tgz",
@@ -28686,6 +28567,15 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.0.tgz",
           "integrity": "sha512-mjUwX3XSoreoxCS3sXS3pSRsGnUjl9T06KBqt/T7AgE9Sgp4diH64ZyURJKnj2T5WmCvTbC0Dm+mwQV5hfLSBQ=="
+        },
+        "uint8-varint": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.1.tgz",
+          "integrity": "sha512-euvmpuulJstK5+xNuI4S1KfnxJnbI5QP52RXIR3GZ3/ZMkOsEK2AgCtFpNvEQLXMxMx2o0qcyevK1fJwOZJagQ==",
+          "requires": {
+            "uint8arraylist": "^2.0.0",
+            "uint8arrays": "^4.0.2"
+          }
         }
       }
     },
@@ -28786,30 +28676,6 @@
         "uint8arrays": "^4.0.2"
       },
       "dependencies": {
-        "long": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-          "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-        },
-        "protobufjs": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-          "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
-          }
-        },
         "protons-runtime": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
@@ -28853,30 +28719,6 @@
             "varint": "^6.0.0"
           }
         },
-        "long": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-          "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-        },
-        "protobufjs": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-          "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
-          }
-        },
         "protons-runtime": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
@@ -28914,30 +28756,6 @@
         "uint8arrays": "^4.0.2"
       },
       "dependencies": {
-        "long": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-          "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-        },
-        "protobufjs": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-          "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
-          }
-        },
         "protons-runtime": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
@@ -28989,32 +28807,6 @@
         "uint8arrays": "^4.0.2"
       },
       "dependencies": {
-        "long": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-          "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A==",
-          "dev": true
-        },
-        "protobufjs": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-          "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-          "dev": true,
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
-          }
-        },
         "protons-runtime": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.0.tgz",
@@ -29195,12 +28987,6 @@
         }
       }
     },
-    "@multiformats/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==",
-      "dev": true
-    },
     "@multiformats/mafmt": {
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-11.1.2.tgz",
@@ -29261,6 +29047,24 @@
             "uint8arrays": "^4.0.2",
             "varint": "^6.0.0"
           }
+        }
+      }
+    },
+    "@multiformats/murmur3": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@multiformats/murmur3/-/murmur3-2.1.6.tgz",
+      "integrity": "sha512-kpJDN+o8B0gJaaqbdV/spIVPj35hqew4rEw8VzPmcITsLpHSgP8pJDeaVaGGVeX/UM8n4IGctLCxw7PBfVks+A==",
+      "dev": true,
+      "requires": {
+        "multiformats": "^12.0.1",
+        "murmurhash3js-revisited": "^3.0.0"
+      },
+      "dependencies": {
+        "multiformats": {
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+          "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
+          "dev": true
         }
       }
     },
@@ -30276,12 +30080,6 @@
       "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
       "dev": true
     },
-    "@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "dev": true
-    },
     "@types/mdast": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.11.tgz",
@@ -31213,11 +31011,110 @@
         }
       }
     },
-    "blakejs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
-      "dev": true
+    "blockstore-core": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/blockstore-core/-/blockstore-core-4.3.3.tgz",
+      "integrity": "sha512-+CyaLkkI7fUKCV/zTQTUmRjejgl1cyynjMZtoeYMXzp/024oy7HlUQZbcoLjxiqzlejMq2S4LD0iyRae2k67+g==",
+      "dev": true,
+      "requires": {
+        "@libp2p/logger": "^3.0.0",
+        "err-code": "^3.0.1",
+        "interface-blockstore": "^5.0.0",
+        "interface-store": "^5.0.0",
+        "it-drain": "^3.0.1",
+        "it-filter": "^3.0.0",
+        "it-merge": "^3.0.1",
+        "it-pushable": "^3.0.0",
+        "multiformats": "^12.0.1",
+        "uint8arrays": "^4.0.2"
+      },
+      "dependencies": {
+        "@libp2p/logger": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-3.0.2.tgz",
+          "integrity": "sha512-2JtRGBXiGfm1t5XneUIXQ2JusW7QwyYmxsW7hSAYS5J73RQJUicpt5le5obVRt7+OM39ei+nWEuC6Xvm1ugHkw==",
+          "dev": true,
+          "requires": {
+            "@libp2p/interface": "^0.1.2",
+            "@multiformats/multiaddr": "^12.1.5",
+            "debug": "^4.3.4",
+            "interface-datastore": "^8.2.0",
+            "multiformats": "^12.0.1"
+          }
+        },
+        "@multiformats/multiaddr": {
+          "version": "12.1.7",
+          "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.7.tgz",
+          "integrity": "sha512-MZRj+uUrtF2WqgByrsPolrdyPDSFstw7Fe0ewabWgWl27fcOmfDOSrEt2aUVkSzapXbyCG7JQh0QvimmTF4aMA==",
+          "dev": true,
+          "requires": {
+            "@chainsafe/is-ip": "^2.0.1",
+            "@chainsafe/netmask": "^2.0.0",
+            "@libp2p/interface": "^0.1.1",
+            "dns-over-http-resolver": "^2.1.0",
+            "multiformats": "^12.0.1",
+            "uint8-varint": "^2.0.1",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "interface-datastore": {
+          "version": "8.2.4",
+          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.4.tgz",
+          "integrity": "sha512-5ng8eSfuynvywa6/5FHbYdyBMrzMdRqcH+xk48hZMr1F+wmLM5Qkh9QuLtYIlTkpUn5INB4vNBONC+swHiLgpA==",
+          "dev": true,
+          "requires": {
+            "interface-store": "^5.0.0",
+            "nanoid": "^4.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        },
+        "interface-store": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.3.tgz",
+          "integrity": "sha512-zAarfBW08mhReqsWy1f6R3aoCmYOkxBH6LONugVtM6d9mmcmqpoYmMnIRoLmM1jtCuP9/OvSvL4kJio1TCWREw==",
+          "dev": true
+        },
+        "it-drain": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-3.0.3.tgz",
+          "integrity": "sha512-l4s+izxUpFAR2axprpFiCaq0EtxK1QMd0LWbEtau5b+OegiZ5xdRtz35iJyh6KZY9QtuwEiQxydiOfYJc7stoA==",
+          "dev": true
+        },
+        "it-filter": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/it-filter/-/it-filter-3.0.3.tgz",
+          "integrity": "sha512-2zXUrJuuV6QHM21ahc8NqVUUxkLMVDWXBoUBcj9GCQLQez2OXmddTHN0r0F5B+TkNTpeL618yIgXi1HNPJOxow==",
+          "dev": true,
+          "requires": {
+            "it-peekable": "^3.0.0"
+          }
+        },
+        "it-merge": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/it-merge/-/it-merge-3.0.2.tgz",
+          "integrity": "sha512-bMk2km8lTz+Rwv30hzDUdGIcqQkOemFJqmGT2wqQZ6/zHKCsYqdRunPrteCqHLV/nIVhUK8nZZkDA2eJ4MJZiA==",
+          "dev": true,
+          "requires": {
+            "it-pushable": "^3.2.0"
+          }
+        },
+        "multiformats": {
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+          "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
+          "dev": true
+        },
+        "uint8-varint": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.1.tgz",
+          "integrity": "sha512-euvmpuulJstK5+xNuI4S1KfnxJnbI5QP52RXIR3GZ3/ZMkOsEK2AgCtFpNvEQLXMxMx2o0qcyevK1fJwOZJagQ==",
+          "dev": true,
+          "requires": {
+            "uint8arraylist": "^2.0.0",
+            "uint8arrays": "^4.0.2"
+          }
+        }
+      }
     },
     "boolean": {
       "version": "3.2.0",
@@ -31790,35 +31687,6 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
-    },
-    "cids": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/cids/-/cids-1.1.9.tgz",
-      "integrity": "sha512-l11hWRfugIcbGuTZwAM5PwpjPPjyb6UZOGwlHSnOBV5o07XhQ4gNpBN67FbODvpjyHtd+0Xs6KNvUcGBiDRsdg==",
-      "dev": true,
-      "requires": {
-        "multibase": "^4.0.1",
-        "multicodec": "^3.0.1",
-        "multihashes": "^4.0.1",
-        "uint8arrays": "^3.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-          "dev": true
-        },
-        "uint8arrays": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-          "dev": true,
-          "requires": {
-            "multiformats": "^9.4.2"
-          }
-        }
-      }
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -34644,18 +34512,130 @@
       }
     },
     "go-libp2p": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/go-libp2p/-/go-libp2p-0.0.6.tgz",
-      "integrity": "sha512-zt11CiU29EPFnlPBmZ5wnGmhi7hzj1qJLhainTbtTqMiFeqqCeJE6E7K6B/0n+EEF0aIeanqelughcWNzZr7Mw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/go-libp2p/-/go-libp2p-1.1.1.tgz",
+      "integrity": "sha512-dSyteUFY1T+8PllfS1wDzyi0uPxapaIAQfwoo39nUZMKqo08NtPxTPI/3oVwIIP1cX5jZuJUXVMDjCGW/3Vqdg==",
       "dev": true,
       "requires": {
+        "blockstore-core": "^4.2.0",
         "cachedir": "^2.3.0",
-        "got": "^11.7.0",
+        "delay": "^6.0.0",
+        "got": "^12.5.3",
         "gunzip-maybe": "^1.4.2",
-        "ipfs-only-hash": "^4.0.0",
-        "pkg-conf": "^3.1.0",
+        "ipfs-unixfs-importer": "^15.1.5",
+        "it-last": "^3.0.2",
+        "multiformats": "^11.0.2",
+        "p-retry": "^5.1.2",
+        "pkg-conf": "^4.0.0",
         "tar-fs": "^2.1.0",
+        "uint8arrays": "^4.0.3",
         "unzip-stream": "^0.3.0"
+      },
+      "dependencies": {
+        "@sindresorhus/is": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+          "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+          "dev": true
+        },
+        "@szmarczak/http-timer": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+          "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+          "dev": true,
+          "requires": {
+            "defer-to-connect": "^2.0.1"
+          }
+        },
+        "cacheable-lookup": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+          "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+          "dev": true
+        },
+        "cacheable-request": {
+          "version": "10.2.13",
+          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.13.tgz",
+          "integrity": "sha512-3SD4rrMu1msNGEtNSt8Od6enwdo//U9s4ykmXfA2TD58kcLkCobtCDiby7kNyj7a/Q7lz/mAesAFI54rTdnvBA==",
+          "dev": true,
+          "requires": {
+            "@types/http-cache-semantics": "^4.0.1",
+            "get-stream": "^6.0.1",
+            "http-cache-semantics": "^4.1.1",
+            "keyv": "^4.5.3",
+            "mimic-response": "^4.0.0",
+            "normalize-url": "^8.0.0",
+            "responselike": "^3.0.0"
+          }
+        },
+        "delay": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/delay/-/delay-6.0.0.tgz",
+          "integrity": "sha512-2NJozoOHQ4NuZuVIr5CWd0iiLVIRSDepakaovIN+9eIDHEhdCAEvSy2cuf1DCrPPQLvHmbqTHODlhHg8UCy4zw==",
+          "dev": true
+        },
+        "got": {
+          "version": "12.6.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
+          "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
+          "dev": true,
+          "requires": {
+            "@sindresorhus/is": "^5.2.0",
+            "@szmarczak/http-timer": "^5.0.1",
+            "cacheable-lookup": "^7.0.0",
+            "cacheable-request": "^10.2.8",
+            "decompress-response": "^6.0.0",
+            "form-data-encoder": "^2.1.2",
+            "get-stream": "^6.0.1",
+            "http2-wrapper": "^2.1.10",
+            "lowercase-keys": "^3.0.0",
+            "p-cancelable": "^3.0.0",
+            "responselike": "^3.0.0"
+          }
+        },
+        "http2-wrapper": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
+          "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
+          "dev": true,
+          "requires": {
+            "quick-lru": "^5.1.1",
+            "resolve-alpn": "^1.2.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+          "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+          "dev": true
+        },
+        "mimic-response": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+          "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+          "dev": true
+        },
+        "normalize-url": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+          "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
+          "dev": true
+        },
+        "p-cancelable": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+          "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+          "dev": true
+        },
+        "responselike": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+          "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+          "dev": true,
+          "requires": {
+            "lowercase-keys": "^3.0.0"
+          }
+        }
       }
     },
     "gopd": {
@@ -34731,30 +34711,13 @@
       }
     },
     "hamt-sharding": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-2.0.1.tgz",
-      "integrity": "sha512-vnjrmdXG9dDs1m/H4iJ6z0JFI2NtgsW5keRkTcM85NGak69Mkf5PHUqBz+Xs0T4sg0ppvj9O5EGAJo40FTxmmA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/hamt-sharding/-/hamt-sharding-3.0.2.tgz",
+      "integrity": "sha512-f0DzBD2tSmLFdFsLAvOflIBqFPjerbA7BfmwO8mVho/5hXwgyyYhv+ijIzidQf/DpDX3bRjAQvhGoBFj+DBvPw==",
       "dev": true,
       "requires": {
         "sparse-array": "^1.3.1",
-        "uint8arrays": "^3.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-          "dev": true
-        },
-        "uint8arrays": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-          "dev": true,
-          "requires": {
-            "multiformats": "^9.4.2"
-          }
-        }
+        "uint8arrays": "^4.0.2"
       }
     },
     "handlebars": {
@@ -35033,6 +34996,30 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
+    "interface-blockstore": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/interface-blockstore/-/interface-blockstore-5.2.5.tgz",
+      "integrity": "sha512-xqu9/8Q3spKUe21eLl7+AGFlzsWZxMNKwvbTJdYJIenG3pL4QKlZQl18RNzVVzMK8GXOgDWDe8gSIP/rldHJAg==",
+      "dev": true,
+      "requires": {
+        "interface-store": "^5.0.0",
+        "multiformats": "^12.0.1"
+      },
+      "dependencies": {
+        "interface-store": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.3.tgz",
+          "integrity": "sha512-zAarfBW08mhReqsWy1f6R3aoCmYOkxBH6LONugVtM6d9mmcmqpoYmMnIRoLmM1jtCuP9/OvSvL4kJio1TCWREw==",
+          "dev": true
+        },
+        "multiformats": {
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+          "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
+          "dev": true
+        }
+      }
+    },
     "interface-datastore": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-7.0.4.tgz",
@@ -35041,17 +35028,6 @@
         "interface-store": "^3.0.0",
         "nanoid": "^4.0.0",
         "uint8arrays": "^4.0.2"
-      }
-    },
-    "interface-ipld-format": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/interface-ipld-format/-/interface-ipld-format-1.0.1.tgz",
-      "integrity": "sha512-WV/ar+KQJVoQpqRDYdo7YPGYIUHJxCuOEhdvsRpzLqoOIVCqPKdMMYmsLL1nCRsF3yYNio+PAJbCKiv6drrEAg==",
-      "dev": true,
-      "requires": {
-        "cids": "^1.1.6",
-        "multicodec": "^3.0.1",
-        "multihashes": "^4.0.2"
       }
     },
     "interface-store": {
@@ -35099,190 +35075,76 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
       "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng=="
     },
-    "ipfs-only-hash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ipfs-only-hash/-/ipfs-only-hash-4.0.0.tgz",
-      "integrity": "sha512-TE1DZCvfw8i3gcsTq3P4TFx3cKFJ3sluu/J3XINkJhIN9OwJgNMqKA+WnKx6ByCb1IoPXsTp1KM7tupElb6SyA==",
-      "dev": true,
-      "requires": {
-        "ipfs-unixfs-importer": "^7.0.1",
-        "meow": "^9.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "meow": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-          "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
-          "dev": true,
-          "requires": {
-            "@types/minimist": "^1.2.0",
-            "camelcase-keys": "^6.2.2",
-            "decamelize": "^1.2.0",
-            "decamelize-keys": "^1.1.0",
-            "hard-rejection": "^2.1.0",
-            "minimist-options": "4.1.0",
-            "normalize-package-data": "^3.0.0",
-            "read-pkg-up": "^7.0.1",
-            "redent": "^3.0.0",
-            "trim-newlines": "^3.0.0",
-            "type-fest": "^0.18.0",
-            "yargs-parser": "^20.2.3"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-          "dev": true,
-          "requires": {
-            "find-up": "^4.1.0",
-            "read-pkg": "^5.2.0",
-            "type-fest": "^0.8.1"
-          },
-          "dependencies": {
-            "type-fest": {
-              "version": "0.8.1",
-              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-              "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-              "dev": true
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "20.2.9",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-          "dev": true
-        }
-      }
-    },
     "ipfs-unixfs": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-4.0.3.tgz",
-      "integrity": "sha512-hzJ3X4vlKT8FQ3Xc4M1szaFVjsc1ZydN+E4VQ91aXxfpjFn9G2wsMo1EFdAXNq/BUnN5dgqIOMP5zRYr3DTsAw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-11.1.0.tgz",
+      "integrity": "sha512-Lq37nKLJOpRFjx3rcg3y+ZwUxBX7jluKfIt5UPp6wb1L3dP0sj1yaLR0Yg2CdGYvHWyUpZD1iTnT8upL0ToDOw==",
       "dev": true,
       "requires": {
         "err-code": "^3.0.1",
-        "protobufjs": "^6.10.2"
+        "protons-runtime": "^5.0.0",
+        "uint8arraylist": "^2.4.3"
+      },
+      "dependencies": {
+        "protons-runtime": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.0.2.tgz",
+          "integrity": "sha512-eKppVrIS5dDh+Y61Yj4bDEOs2sQLQbQGIhr7EBiybPQhIMGBynzVXlYILPWl3Td1GDadobc8qevh5D+JwfG9bw==",
+          "dev": true,
+          "requires": {
+            "protobufjs": "^7.0.0",
+            "uint8arraylist": "^2.4.3"
+          }
+        }
       }
     },
     "ipfs-unixfs-importer": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-7.0.3.tgz",
-      "integrity": "sha512-qeFOlD3AQtGzr90sr5Tq1Bi8pT5Nr2tSI8z310m7R4JDYgZc6J1PEZO3XZQ8l1kuGoqlAppBZuOYmPEqaHcVQQ==",
+      "version": "15.2.1",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-15.2.1.tgz",
+      "integrity": "sha512-9ArBh7Xfz8gUSe8pq9c9ilBOXd1bbT3L+4xnI6w/usWLwnNT14p8WbFZjDD0MO1/PrD0PTUZuHNDS2l4EO+wPg==",
       "dev": true,
       "requires": {
-        "bl": "^5.0.0",
-        "cids": "^1.1.5",
+        "@ipld/dag-pb": "^4.0.0",
+        "@multiformats/murmur3": "^2.0.0",
         "err-code": "^3.0.1",
-        "hamt-sharding": "^2.0.0",
-        "ipfs-unixfs": "^4.0.3",
-        "ipld-dag-pb": "^0.22.2",
-        "it-all": "^1.0.5",
-        "it-batch": "^1.0.8",
-        "it-first": "^1.0.6",
-        "it-parallel-batch": "^1.0.9",
-        "merge-options": "^3.0.4",
-        "multihashing-async": "^2.1.0",
+        "hamt-sharding": "^3.0.0",
+        "interface-blockstore": "^5.0.0",
+        "interface-store": "^5.0.1",
+        "ipfs-unixfs": "^11.0.0",
+        "it-all": "^3.0.2",
+        "it-batch": "^3.0.2",
+        "it-first": "^3.0.2",
+        "it-parallel-batch": "^3.0.1",
+        "multiformats": "^12.0.1",
+        "progress-events": "^1.0.0",
         "rabin-wasm": "^0.1.4",
-        "uint8arrays": "^2.1.2"
+        "uint8arraylist": "^2.4.3",
+        "uint8arrays": "^4.0.2"
       },
       "dependencies": {
+        "interface-store": {
+          "version": "5.1.3",
+          "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-5.1.3.tgz",
+          "integrity": "sha512-zAarfBW08mhReqsWy1f6R3aoCmYOkxBH6LONugVtM6d9mmcmqpoYmMnIRoLmM1jtCuP9/OvSvL4kJio1TCWREw==",
+          "dev": true
+        },
         "it-all": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/it-all/-/it-all-1.0.6.tgz",
-          "integrity": "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
+          "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A==",
           "dev": true
         },
         "it-first": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/it-first/-/it-first-1.0.7.tgz",
-          "integrity": "sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/it-first/-/it-first-3.0.3.tgz",
+          "integrity": "sha512-RC8tplctsDpoBUljwsp1viiyaR5fPvMe+FgbbcU0sFjKkJa7iwbB4CCPhHtVYSdjsrREfr0QEotfQrBoGyt7Dw==",
           "dev": true
         },
         "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+          "version": "12.1.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-12.1.0.tgz",
+          "integrity": "sha512-/qTOKKnU8nwcVURjRcS+UN0QYgdS5BPZzY10Aiciu2SqncyCVMGV8KtD83EBFmsuJDsSEmT4sGvzcTkCoMw0sQ==",
           "dev": true
-        },
-        "uint8arrays": {
-          "version": "2.1.10",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
-          "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
-          "dev": true,
-          "requires": {
-            "multiformats": "^9.4.2"
-          }
-        }
-      }
-    },
-    "ipld-dag-pb": {
-      "version": "0.22.3",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.22.3.tgz",
-      "integrity": "sha512-dfG5C5OVAR4FEP7Al2CrHWvAyIM7UhAQrjnOYOIxXGQz5NlEj6wGX0XQf6Ru6or1na6upvV3NQfstapQG8X2rg==",
-      "dev": true,
-      "requires": {
-        "cids": "^1.0.0",
-        "interface-ipld-format": "^1.0.0",
-        "multicodec": "^3.0.1",
-        "multihashing-async": "^2.0.0",
-        "protobufjs": "^6.10.2",
-        "stable": "^0.1.8",
-        "uint8arrays": "^2.0.5"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-          "dev": true
-        },
-        "uint8arrays": {
-          "version": "2.1.10",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-2.1.10.tgz",
-          "integrity": "sha512-Q9/hhJa2836nQfEJSZTmr+pg9+cDJS9XEAp7N2Vg5MzL3bK/mkMVfjscRGYruP9jNda6MAdf4QD/y78gSzkp6A==",
-          "dev": true,
-          "requires": {
-            "multiformats": "^9.4.2"
-          }
         }
       }
     },
@@ -35857,9 +35719,9 @@
       "integrity": "sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA=="
     },
     "it-batch": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-1.0.9.tgz",
-      "integrity": "sha512-7Q7HXewMhNFltTsAMdSz6luNhyhkhEtGGbYek/8Xb/GiqYMtwUmopE1ocPSiJKKp3rM4Dt045sNFoUu+KZGNyA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-batch/-/it-batch-3.0.3.tgz",
+      "integrity": "sha512-KdKVGOZgYhxiHTMphzPKaiNL99yyUgeDoqRmSedbKJr05nP5RxtiIPWX+i1dLCADRjExbGtKfFsrogNgH0h9SA==",
       "dev": true
     },
     "it-batched-bytes": {
@@ -35904,6 +35766,12 @@
         "p-defer": "^4.0.0",
         "uint8arraylist": "^2.0.0"
       }
+    },
+    "it-last": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/it-last/-/it-last-3.0.3.tgz",
+      "integrity": "sha512-veF0zWTMEJ466Otxz7jPbExiJGfJYTOiHYGfg8iGwKPIV558zIGZQJU1WNyjHfugFzAyfuFlIZKsXCCtCl8LgQ==",
+      "dev": true
     },
     "it-length": {
       "version": "2.0.1",
@@ -35961,12 +35829,12 @@
       }
     },
     "it-parallel-batch": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-1.0.11.tgz",
-      "integrity": "sha512-UWsWHv/kqBpMRmyZJzlmZeoAMA0F3SZr08FBdbhtbe+MtoEBgr/ZUAKrnenhXCBrsopy76QjRH2K/V8kNdupbQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-parallel-batch/-/it-parallel-batch-3.0.2.tgz",
+      "integrity": "sha512-8ci62F5gn5aS8/wEC0kvRKWCmenHlIi+R8waEF/SP1ImQhhkve9l4/DXEmoL7UeI5FqJktzkMzZwqDng0ZppKw==",
       "dev": true,
       "requires": {
-        "it-batch": "^1.0.9"
+        "it-batch": "^3.0.0"
       }
     },
     "it-pb-stream": {
@@ -35981,6 +35849,12 @@
         "uint8arraylist": "^2.0.0"
       }
     },
+    "it-peekable": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-3.0.2.tgz",
+      "integrity": "sha512-nWwUdhNQ1CfAuoJmsaUotNMYUrfNIlY9gBA1jwWfWSu1I0mLY2brwreKHGOUptXLJUiG5pR04He0xYZMWBRiGA==",
+      "dev": true
+    },
     "it-pipe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/it-pipe/-/it-pipe-2.0.5.tgz",
@@ -35992,9 +35866,12 @@
       }
     },
     "it-pushable": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.1.2.tgz",
-      "integrity": "sha512-zU9FbeoGT0f+yobwm8agol2OTMXbq4ZSWLEi7hug6TEZx4qVhGhGyp31cayH04aBYsIoO2Nr5kgMjH/oWj2BJQ=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/it-pushable/-/it-pushable-3.2.1.tgz",
+      "integrity": "sha512-sLFz2Q0oyDCJpTciZog7ipP4vSftfPy3e6JnH6YyztRa1XqkpGQaafK3Jw/JlfEBtCXfnX9uVfcpu3xpSAqCVQ==",
+      "requires": {
+        "p-defer": "^4.0.0"
+      }
     },
     "it-reader": {
       "version": "6.0.2",
@@ -36055,12 +35932,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
       "integrity": "sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==",
-      "dev": true
-    },
-    "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
       "dev": true
     },
     "js-tokens": {
@@ -36192,9 +36063,9 @@
       }
     },
     "keyv": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
-      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
+      "integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
       "dev": true,
       "requires": {
         "json-buffer": "3.0.1"
@@ -36377,41 +36248,10 @@
       }
     },
     "load-json-file": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
-      "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.15",
-        "parse-json": "^4.0.0",
-        "pify": "^4.0.1",
-        "strip-bom": "^3.0.0",
-        "type-fest": "^0.3.0"
-      },
-      "dependencies": {
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-          "dev": true
-        },
-        "type-fest": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
-          "dev": true
-        }
-      }
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-7.0.1.tgz",
+      "integrity": "sha512-Gnxj3ev3mB5TkVBGad0JM6dmLiQL+o0t23JPBZ9sd+yvSLk05mFoqKBw5N8gbbkU4TNXyqCgIrl/VM17OgUIgQ==",
+      "dev": true
     },
     "locate-path": {
       "version": "6.0.0",
@@ -36557,10 +36397,9 @@
       }
     },
     "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "dev": true
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "longbits": {
       "version": "1.1.0",
@@ -37724,15 +37563,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "multibase": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/multibase/-/multibase-4.0.6.tgz",
-      "integrity": "sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==",
-      "dev": true,
-      "requires": {
-        "@multiformats/base-x": "^4.0.1"
-      }
-    },
     "multicast-dns": {
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
@@ -37743,102 +37573,10 @@
         "thunky": "^1.0.2"
       }
     },
-    "multicodec": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.2.1.tgz",
-      "integrity": "sha512-+expTPftro8VAW8kfvcuNNNBgb9gPeNYV9dn+z1kJRWF2vih+/S79f2RVeIwmrJBUJ6NT9IUPWnZDQvegEh5pw==",
-      "dev": true,
-      "requires": {
-        "uint8arrays": "^3.0.0",
-        "varint": "^6.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-          "dev": true
-        },
-        "uint8arrays": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-          "dev": true,
-          "requires": {
-            "multiformats": "^9.4.2"
-          }
-        }
-      }
-    },
     "multiformats": {
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-11.0.2.tgz",
       "integrity": "sha512-b5mYMkOkARIuVZCpvijFj9a6m5wMVLC7cf/jIPd5D/ARDOfLC5+IFkbgDXQgcU2goIsTD/O9NY4DI/Mt4OGvlg=="
-    },
-    "multihashes": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-4.0.3.tgz",
-      "integrity": "sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==",
-      "dev": true,
-      "requires": {
-        "multibase": "^4.0.1",
-        "uint8arrays": "^3.0.0",
-        "varint": "^5.0.2"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-          "dev": true
-        },
-        "uint8arrays": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-          "dev": true,
-          "requires": {
-            "multiformats": "^9.4.2"
-          }
-        },
-        "varint": {
-          "version": "5.0.2",
-          "resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
-          "integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==",
-          "dev": true
-        }
-      }
-    },
-    "multihashing-async": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-2.1.4.tgz",
-      "integrity": "sha512-sB1MiQXPSBTNRVSJc2zM157PXgDtud2nMFUEIvBrsq5Wv96sUclMRK/ecjoP1T/W61UJBqt4tCTwMkUpt2Gbzg==",
-      "dev": true,
-      "requires": {
-        "blakejs": "^1.1.0",
-        "err-code": "^3.0.0",
-        "js-sha3": "^0.8.0",
-        "multihashes": "^4.0.1",
-        "murmurhash3js-revisited": "^3.0.0",
-        "uint8arrays": "^3.0.0"
-      },
-      "dependencies": {
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-          "dev": true
-        },
-        "uint8arrays": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
-          "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
-          "dev": true,
-          "requires": {
-            "multiformats": "^9.4.2"
-          }
-        }
-      }
     },
     "multimatch": {
       "version": "5.0.0",
@@ -41286,12 +41024,6 @@
       "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
       "dev": true
     },
-    "pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true
-    },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
@@ -41308,56 +41040,62 @@
       }
     },
     "pkg-conf": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
-      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-4.0.0.tgz",
+      "integrity": "sha512-7dmgi4UY4qk+4mj5Cd8v/GExPo0K+SlY+hulOSdfZ/T6jVH6//y7NtzZo5WrfhDBxuQ0jCa7fLZmNaNh7EWL/w==",
       "dev": true,
       "requires": {
-        "find-up": "^3.0.0",
-        "load-json-file": "^5.2.0"
+        "find-up": "^6.0.0",
+        "load-json-file": "^7.0.0"
       },
       "dependencies": {
         "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+          "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "^7.1.0",
+            "path-exists": "^5.0.0"
           }
         },
         "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+          "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "^6.0.0"
           }
         },
         "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+          "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "yocto-queue": "^1.0.0"
           }
         },
         "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+          "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "^4.0.0"
           }
         },
         "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+          "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+          "dev": true
+        },
+        "yocto-queue": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+          "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
           "dev": true
         }
       }
@@ -41837,6 +41575,12 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "progress-events": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.0.tgz",
+      "integrity": "sha512-zIB6QDrSbPfRg+33FZalluFIowkbV5Xh1xSuetjG+rlC5he6u2dc6VQJ0TbMdlN3R1RHdpOqxEFMKTnQ+itUwA==",
+      "dev": true
+    },
     "prompt": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.3.0.tgz",
@@ -41884,10 +41628,9 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "6.11.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-      "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
-      "dev": true,
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -41899,9 +41642,8 @@
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
+        "long": "^5.0.0"
       }
     },
     "protons-runtime": {
@@ -41911,32 +41653,6 @@
       "requires": {
         "protobufjs": "^7.0.0",
         "uint8arraylist": "^2.4.3"
-      },
-      "dependencies": {
-        "long": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-          "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-        },
-        "protobufjs": {
-          "version": "7.2.2",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.2.tgz",
-          "integrity": "sha512-++PrQIjrom+bFDPpfmqXfAGSQs40116JRrqqyf53dymUMvvb5d/LMRyicRoF1AUKoXVS1/IgJXlEgcpr4gTF3Q==",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
-          }
-        }
       }
     },
     "pseudomap": {
@@ -43821,12 +43537,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
       "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
-    },
-    "stable": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-      "dev": true
     },
     "stack-trace": {
       "version": "0.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cerc-io/libp2p",
-  "version": "0.42.2-laconic-0.1.2",
+  "version": "0.42.2-laconic-0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cerc-io/libp2p",
-      "version": "0.42.2-laconic-0.1.2",
+      "version": "0.42.2-laconic-0.1.4",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@achingbrain/nat-port-mapper": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "cborg": "^1.8.1",
     "delay": "^5.0.0",
     "execa": "^7.0.0",
-    "go-libp2p": "^0.0.6",
+    "go-libp2p": "^1.1.1",
     "it-to-buffer": "^3.0.1",
     "lodash": "^4.17.21",
     "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerc-io/libp2p",
-  "version": "0.42.2-laconic-0.1.3",
+  "version": "0.42.2-laconic-0.1.4",
   "description": "JavaScript implementation of libp2p, a modular peer to peer network stack",
   "license": "Apache-2.0 OR MIT",
   "homepage": "https://github.com/libp2p/js-libp2p#readme",

--- a/src/webrtc-signal/transport.ts
+++ b/src/webrtc-signal/transport.ts
@@ -135,6 +135,7 @@ export class WebRTCSignal implements Transport, Startable {
         pubsub.subscribe(WEBRTC_SIGNAL_TOPIC)
         subscribed = true
       } catch (err: any) {
+        // Pubsub may not be started yet
         if ((err as Error).message.includes(ERR_PUBSUB_NOT_STARTED)) {
           // Wait before retrying
           await delay(500)

--- a/test/interop.ts
+++ b/test/interop.ts
@@ -52,6 +52,10 @@ async function createGoPeer (options: SpawnOptions): Promise<Daemon> {
     opts.push(`-id=${options.key}`)
   }
 
+  if (options.muxer != null) {
+    opts.push(`-muxer=${options.muxer}`)
+  }
+
   const deferred = pDefer()
   const proc = execa(p2pd(), opts)
 

--- a/test/interop.ts
+++ b/test/interop.ts
@@ -52,6 +52,8 @@ async function createGoPeer (options: SpawnOptions): Promise<Daemon> {
     opts.push(`-id=${options.key}`)
   }
 
+  // Use only the required muxer as js-libp2p nodes run into an error causing the mplex muxer tests to fail
+  // with error "failed to negotiate stream multiplexer: protocols not supported: [/yamux/1.0.0]"
   if (options.muxer != null) {
     opts.push(`-muxer=${options.muxer}`)
   }


### PR DESCRIPTION
Part of https://github.com/cerc-io/watcher-ts/issues/409

- Handle pubsub error in `webrtc-signal` component start
  - We are calling `pubsub.subscribe()` in the start process of `webrtc-signal` component
  - When starting all the libp2p components, if `pubsub.subscribe()` call happens before the pubsub service has started, it throws an error; encountered when using `gossipsub`
  - Catch the corresponding error and retry after a short delay
- Upgrade npm `go-libp2p` package
  - Required as one of the binaries referenced in the post-install script of current version is no longer available on IPFS
- Use only the required muxer in the Go nodes for interop tests as JS nodes run into an error when testing for `mplex` muxer and both `mplex` and `yamux` are turned on the Go side